### PR TITLE
chore: harden user session cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Architecture Notes
+
+- [Pending architecture improvements](docs/architecture-improvements.md)
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/docs/architecture-improvements.md
+++ b/docs/architecture-improvements.md
@@ -1,0 +1,48 @@
+# Architecture Improvements
+
+## Event Home Aggregated Data Endpoint
+
+### Status
+
+Pending backend coordination. No frontend or backend behavior should change until the API contract is agreed with the backend owner.
+
+### Current Flow
+
+`EventsContainer` loads the event list and then requests the full detail for every event so each card can determine its member and payment state. For an authenticated user, this produces:
+
+1. One request for the event list.
+2. One request for the user's debtor state.
+3. One `getEventById` request per event displayed.
+
+The requests now run server-side, so they do not generate repeated browser Server Action requests. However, the backend workload still grows linearly with the number of events ($N + 2$ requests).
+
+### Proposed Backend Contract
+
+Expose one authenticated endpoint dedicated to the event home. The endpoint should return all data required to render the cards:
+
+```ts
+interface EventHomeResponse {
+  events: IEvent[];
+  debtorEventId: string | null;
+}
+```
+
+The response should preserve the current visibility rules:
+
+- Authenticated users receive public and eligible private events.
+- Unauthenticated users receive only public events.
+- `debtorEventId` is derived from the authenticated user, not from a user ID supplied by the client.
+
+If returning the full `IEvent` shape is too large, define a dedicated `IEventHomeCard` DTO containing the current card fields plus the member identifiers needed to calculate participation.
+
+### Frontend Follow-up
+
+After the endpoint is available, update `EventsContainer` to make one server-side request and pass the returned event details and debtor state to `EventCard`. Remove the individual calls to `getEventById` and `isUserDebtor` from that container.
+
+### Acceptance Criteria
+
+- Loading `eventHome` makes one backend request for its event data.
+- The endpoint derives identity from the JWT and never trusts a client-provided user ID.
+- Public and authenticated event visibility remains unchanged.
+- Existing card states remain unchanged: available, subscribed, full, canceled, closed, finished, ready for payment, debtor, and blocked.
+- Add backend integration coverage for public users, authenticated users, and users with outstanding debt.

--- a/src/utils/cookies/localeCookies.ts
+++ b/src/utils/cookies/localeCookies.ts
@@ -12,27 +12,3 @@ export interface IUserFromCookie {
   id: string;
   name: string;
 }
-
-/**
- * Lee el valor de la cookie 'user' si existe.
- */
-export function getUserFromCookie(): IUserFromCookie | null {
-  if (typeof document === 'undefined') return null;
-
-  const match = document.cookie.match(/(?:^|; )user=([^;]*)/);
-  if (!match) return null;
-
-  try {
-    const parsed = JSON.parse(decodeURIComponent(match[1]));
-
-    const user: IUserFromCookie = {
-      id: parsed.id,
-      name: parsed.name,
-    };
-
-    return user;
-  } catch (e) {
-    console.error('Error parsing user cookie:', e);
-    return null;
-  }
-}

--- a/src/utils/cookies/localeCookiesServer.ts
+++ b/src/utils/cookies/localeCookiesServer.ts
@@ -52,7 +52,7 @@ export async function setAuthCookies(jwt: string, user: IUserFromCookie): Promis
 
   cookieStore.set(AUTH_COOKIE_NAMES.user, encodeURIComponent(JSON.stringify(user)), {
     ...AUTH_COOKIE_OPTIONS,
-    httpOnly: false,
+    httpOnly: true,
   });
 }
 


### PR DESCRIPTION
## Summary

- Mark the `user` session cookie as `httpOnly` so browser JavaScript cannot read or modify it.
- Remove the unused client-side user-cookie reader.
- Document the pending `eventHome` backend aggregation endpoint, including the proposed contract and acceptance criteria.

## Validation

- `npx tsc --noEmit`
- `npx prettier --check README.md docs/architecture-improvements.md src/utils/cookies/localeCookies.ts src/utils/cookies/localeCookiesServer.ts`
- `git diff --check`

## Notes

- No backend behavior was changed.
- `pnpm-lock.yaml` and `pnpm-workspace.yaml` are intentionally excluded.